### PR TITLE
Riordino spaziatura header: logo più grande e spazio titolo aumentato (Vibe Kanban)

### DIFF
--- a/lemmario-dashboard/components/Header.tsx
+++ b/lemmario-dashboard/components/Header.tsx
@@ -93,14 +93,14 @@ export function Header() {
       <div className="relative z-10 max-w-[1600px] mx-auto px-2 md:px-4 py-1">
         <div className="flex items-center justify-between gap-2">
           {/* Left: Logo + Title */}
-          <div className="flex items-center gap-2 flex-shrink-0 max-w-[480px] lg:max-w-[560px]">
+          <div className="flex items-center gap-2 flex-shrink-0 max-w-[580px] lg:max-w-[660px]">
             <Image
               src="/AtLiTeG_logo.webp"
               alt="AtLiTeG Logo"
-              width={50}
-              height={55}
+              width={70}
+              height={77}
               priority
-              className="w-10 h-auto md:w-[50px] flex-shrink-0"
+              className="w-10 h-auto md:w-[70px] flex-shrink-0"
             />
             <div className="hidden md:block">
               <h1 className="text-white text-[16px] lg:text-[17px] font-bold leading-[1.25]">


### PR DESCRIPTION
## Modifiche apportate

- **Logo ingrandito**: Aumentata dimensione del logo AtLiTeG da 50x55px a 70x77px nella versione desktop, mantenendo la proporzione originale
- **Spazio titolo aumentato**: Incrementato di 100px lo spazio orizzontale dedicato al blocco logo+titolo (da max-w-[480px]/[560px] a max-w-[580px]/[660px] per desktop/large)

## Motivazione

Il layout precedente dell'header presentava due problematiche di usabilità:
1. Il logo risultava troppo piccolo nella versione desktop
2. Lo spazio disponibile per titolo e sottotitolo era eccessivamente stretto, limitando la leggibilità

Queste modifiche migliorano l'equilibrio visivo dell'header e la gerarchia degli elementi.

## Dettagli implementazione

File modificato: `lemmario-dashboard/components/Header.tsx`

- Aggiornati gli attributi `width` e `height` del componente Next.js Image (70x77px)
- Modificata la classe Tailwind per il rendering responsive: `md:w-[70px]`
- Aumentati i vincoli di `max-w` del contenitore per garantire spazio adeguato su schermi desktop e large

---

This PR was written using [Vibe Kanban](https://vibekanban.com)