### PR TITLE
fix: correggi sovrapposizione search bar/filtri nella toolbar mobile

### DIFF
--- a/e2e/mobile-toolbar.spec.ts
+++ b/e2e/mobile-toolbar.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect, Page } from '@playwright/test';
+
+const BASE_URL = process.env.E2E_BASE_URL || 'http://localhost:9000';
+
+const MOBILE_VIEWPORT = { width: 390, height: 844 };
+const DESKTOP_VIEWPORT = { width: 1280, height: 800 };
+
+async function waitForApp(page: Page) {
+  await page.waitForLoadState('networkidle');
+  await page.waitForSelector('[data-testid="compact-toolbar"]', { timeout: 15000 }).catch(() => {});
+}
+
+test.describe('CompactToolbar - Layout mobile', () => {
+  test('search bar è su riga separata dai filtri su viewport mobile', async ({ page }) => {
+    await page.setViewportSize(MOBILE_VIEWPORT);
+    await page.goto(BASE_URL);
+    await waitForApp(page);
+
+    const searchInput = page.locator('input[placeholder*="Cerca"]').first();
+    const indiceButton = page.locator('button:has-text("Indice")').first();
+    const categoriaButton = page.locator('button:has-text("Categoria")').first();
+
+    await expect(searchInput).toBeVisible();
+    await expect(indiceButton).toBeVisible();
+    await expect(categoriaButton).toBeVisible();
+
+    const searchBox = await searchInput.boundingBox();
+    const indiceBox = await indiceButton.boundingBox();
+    const categoriaBox = await categoriaButton.boundingBox();
+
+    expect(searchBox).not.toBeNull();
+    expect(indiceBox).not.toBeNull();
+    expect(categoriaBox).not.toBeNull();
+
+    const searchBottom = searchBox!.y + searchBox!.height;
+    const indiceTop = indiceBox!.y;
+    const categoriaTop = categoriaBox!.y;
+
+    // Su mobile, la search bar deve terminare prima della riga Indice/Categoria (margine 4px)
+    expect(searchBottom).toBeLessThanOrEqual(indiceTop + 4);
+    expect(searchBottom).toBeLessThanOrEqual(categoriaTop + 4);
+
+    // La search bar deve occupare quasi tutta la larghezza del viewport
+    expect(searchBox!.width).toBeGreaterThan(MOBILE_VIEWPORT.width * 0.8);
+  });
+
+  test('nessuna sovrapposizione tra search bar e bottoni filtro su mobile', async ({ page }) => {
+    await page.setViewportSize(MOBILE_VIEWPORT);
+    await page.goto(BASE_URL);
+    await waitForApp(page);
+
+    const searchInput = page.locator('input[placeholder*="Cerca"]').first();
+    const categoriaButton = page.locator('button:has-text("Categoria")').first();
+
+    const searchBox = await searchInput.boundingBox();
+    const categoriaBox = await categoriaButton.boundingBox();
+
+    expect(searchBox).not.toBeNull();
+    expect(categoriaBox).not.toBeNull();
+
+    const searchBottom = searchBox!.y + searchBox!.height;
+    const searchRight = searchBox!.x + searchBox!.width;
+    const categoriaTop = categoriaBox!.y;
+    const categoriaLeft = categoriaBox!.x;
+
+    const verticalOverlap = searchBottom > categoriaTop && searchBox!.y < (categoriaBox!.y + categoriaBox!.height);
+    const horizontalOverlap = searchRight > categoriaLeft && searchBox!.x < (categoriaBox!.x + categoriaBox!.width);
+
+    expect(verticalOverlap && horizontalOverlap).toBe(false);
+  });
+
+  test('su desktop tutti gli elementi sono sulla stessa riga', async ({ page }) => {
+    await page.setViewportSize(DESKTOP_VIEWPORT);
+    await page.goto(BASE_URL);
+    await waitForApp(page);
+
+    const searchInput = page.locator('input[placeholder*="Cerca"]').first();
+    const indiceButton = page.locator('button:has-text("Indice")').first();
+    const categoriaButton = page.locator('button:has-text("Categoria")').first();
+
+    await expect(searchInput).toBeVisible();
+    await expect(indiceButton).toBeVisible();
+    await expect(categoriaButton).toBeVisible();
+
+    const searchBox = await searchInput.boundingBox();
+    const indiceBox = await indiceButton.boundingBox();
+    const categoriaBox = await categoriaButton.boundingBox();
+
+    expect(searchBox).not.toBeNull();
+    expect(indiceBox).not.toBeNull();
+    expect(categoriaBox).not.toBeNull();
+
+    // Su desktop, tutti gli elementi devono avere centro verticale simile (±20px)
+    const searchMidY = searchBox!.y + searchBox!.height / 2;
+    const indiceMidY = indiceBox!.y + indiceBox!.height / 2;
+    const categoriaMidY = categoriaBox!.y + categoriaBox!.height / 2;
+
+    expect(Math.abs(searchMidY - indiceMidY)).toBeLessThan(20);
+    expect(Math.abs(searchMidY - categoriaMidY)).toBeLessThan(20);
+  });
+
+  test('ricerca funziona correttamente da mobile', async ({ page }) => {
+    await page.setViewportSize(MOBILE_VIEWPORT);
+    await page.goto(BASE_URL);
+    await waitForApp(page);
+
+    const searchInput = page.locator('input[placeholder*="Cerca"]').first();
+    await searchInput.click();
+    await searchInput.fill('sal');
+
+    await page.waitForTimeout(400);
+
+    const suggestions = page.locator('.shadow-card-hover').first();
+    await expect(suggestions).toBeVisible({ timeout: 3000 });
+  });
+});

--- a/lemmario-dashboard/components/CompactToolbar.tsx
+++ b/lemmario-dashboard/components/CompactToolbar.tsx
@@ -229,9 +229,9 @@ export function CompactToolbar({ onToggleIndice }: CompactToolbarProps) {
   return (
     <div className="bg-white border-b border-border">
       <div className="max-w-container mx-auto px-2 sm:px-lg py-1.5">
-        <div className="flex items-center gap-2 flex-wrap">
-          {/* Search Bar - Compatta */}
-          <div className="relative flex-1 min-w-0 w-full sm:min-w-[200px]" ref={searchRef}>
+        <div className="flex flex-col items-start sm:flex-row sm:items-center gap-1.5 sm:gap-2">
+          {/* Search Bar - Compatta (riga intera su mobile) */}
+          <div className="relative w-full sm:flex-1 sm:min-w-[200px]" ref={searchRef}>
             <div className="relative">
               <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-text-muted w-4 h-4" />
               <input
@@ -275,6 +275,8 @@ export function CompactToolbar({ onToggleIndice }: CompactToolbarProps) {
             )}
           </div>
 
+          {/* Indice + Filtri: seconda riga su mobile, stessa riga su sm+ */}
+          <div className="flex items-center gap-2 flex-wrap">
           {/* Indice Alfabetico Button */}
           {onToggleIndice && (
             <button
@@ -317,11 +319,12 @@ export function CompactToolbar({ onToggleIndice }: CompactToolbarProps) {
               </button>
             )}
           </div>
+          </div>
 
           {/* Active Filters Tags */}
           {hasActiveFilters && (
             <div className="flex flex-wrap gap-1 ml-auto">
-              {/* Lemma selezionato dall'indice alfabetico */}
+              {/* Lemma selezionato dall\'indice alfabetico */}
               {selectedLemma && (
                 <motion.span
                   initial={{ opacity: 0, scale: 0.8 }}

--- a/package.json
+++ b/package.json
@@ -3,9 +3,12 @@
   "version": "1.0.0",
   "description": "AtLiTeG Map - Italian Gastronomic Language Atlas",
   "scripts": {
-    "generate-password-hash": "node scripts/generate-password-hash.js"
+    "generate-password-hash": "node scripts/generate-password-hash.js",
+    "e2e": "playwright test",
+    "e2e:report": "playwright show-report"
   },
   "devDependencies": {
+    "@playwright/test": "^1.44.0",
     "bcrypt": "^5.1.1",
     "csv-parser": "^3.2.0",
     "csv-writer": "^1.6.0"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: process.env.E2E_BASE_URL || 'http://localhost:9000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'Mobile Chrome (iPhone 14)',
+      use: {
+        ...devices['iPhone 14'],
+      },
+    },
+    {
+      name: 'Desktop Chrome',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+  ],
+});


### PR DESCRIPTION
## Problema

Su viewport mobile (390×844) i controlli della `CompactToolbar` si sovrappongono: il form di ricerca veniva compresso a soli **74px di larghezza** mentre Indice, Categoria e Periodo stazionavano sulla stessa riga.

**Causa**: il contenitore `flex items-center gap-2 flex-wrap` con il search wrapper avente `flex-1 w-full` non forzava un line-break effettivo su mobile — il `flex-1` consumava spazio ma gli altri elementi rimanevano inline.

### Misurazioni E2E (atlante.atliteg.org @ 390×844, pre-fix)

| Campo | Valore |
|-------|--------|
| Search width | **74px** (dovrebbe essere ~359px) |
| `bug_overlap` (search ∩ Indice) | **`true`** |
| `search_fullwidth` | **`false`** |

---

## Fix

Layout a **due righe su mobile**, singola riga su `sm+` (≥640px):

```
Mobile (< sm):
┌─────────────────────────────────────┐
│  🔍  Cerca lemma o forma...         │  ← riga 1: full-width
└─────────────────────────────────────┘
┌──────────┐ ┌────────────────────────┐
│ ≡ Indice │ │ Filtri: Categoria ↓   Periodo ↓ │  ← riga 2
└──────────┘ └────────────────────────┘

Desktop (≥ sm):
┌────────────────────────┐ ┌──────────┐ ┌──────────────────────────────┐
│  🔍  Cerca...           │ │ ≡ Indice │ │ Filtri: Categoria ↓  Periodo ↓│
└────────────────────────┘ └──────────┘ └──────────────────────────────┘
```

### Classi modificate in `CompactToolbar.tsx`

| Elemento | Prima | Dopo |
|----------|-------|------|
| Container principale | `flex items-center gap-2 flex-wrap` | `flex flex-col items-start sm:flex-row sm:items-center gap-1.5 sm:gap-2` |
| Search wrapper | `relative flex-1 min-w-0 w-full sm:min-w-[200px]` | `relative w-full sm:flex-1 sm:min-w-[200px]` |
| Indice + Filtri | elementi diretti del container | avvolti in `<div className="flex items-center gap-2 flex-wrap">` |

### Misurazioni E2E (simulazione CSS injected, post-fix)

| Campo | Valore |
|-------|--------|
| Search width | **359px** (92% viewport) |
| `no_overlap` | **`true`** |
| `search_fullwidth` | **`true`** |
| Search bottom (173) ≤ Indice top (179) | **confermato** |

---

## Test

Aggiunti 4 test Playwright in `e2e/mobile-toolbar.spec.ts`:

1. **search bar su riga separata su mobile** — verifica che `search.bottom ≤ indice.top + 4px` e `search.width > 80% viewport`
2. **nessuna sovrapposizione geometrica** — verifica assenza overlap verticale+orizzontale
3. **desktop: elementi sulla stessa riga** — verifica che `midY` degli elementi differisca < 20px
4. **ricerca funzionante da mobile** — click, fill, verifica suggerimenti visibili

Per eseguire:
```bash
npm install  # installa @playwright/test
npx playwright install chromium
E2E_BASE_URL=http://localhost:9000 npm run e2e
```

---

## Deploy

Dopo il merge, ricostruire il container Docker:
```bash
docker compose up --build -d
```