### PR TITLE
fix(ci): pass deploy secrets via job env to fix admin login after deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -21,7 +21,23 @@ jobs:
     environment:
       name: production
       url: ${{ vars.PRODUCTION_URL }}
-    
+
+    # Env a livello di job: GitHub Actions inietta i secret direttamente
+    # nell'environment del processo, senza passare da interpolazione shell.
+    # In questo modo password con caratteri speciali ($, ", `, \, !, ecc.)
+    # arrivano integre a `docker compose`, che le usa per la sostituzione
+    # ${VAR} nel compose file con precedenza sulla `.env` del repo.
+    env:
+      FRONTEND_API_KEYS: ${{ secrets.FRONTEND_API_KEYS }}
+      NEXT_PUBLIC_API_KEY: ${{ secrets.NEXT_PUBLIC_API_KEY }}
+      ADMIN_USERNAME: ${{ secrets.ADMIN_USERNAME }}
+      ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
+      ADMIN_PASSWORD_HASH: ""
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      ALLOWED_ORIGINS: ${{ secrets.ALLOWED_ORIGINS }}
+      NEXT_PUBLIC_API_URL: ""
+      NEXT_PUBLIC_SITE_URL: ${{ secrets.NEXT_PUBLIC_SITE_URL }}
+
     steps:
       # Step 1: Informazioni di avvio
       - name: 🚀 Inizio Deploy
@@ -143,22 +159,9 @@ jobs:
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
           
           cd ${{ secrets.DEPLOY_PATH }}
-          
-          # Export environment variables for docker compose
-          export FRONTEND_API_KEYS="${{ secrets.FRONTEND_API_KEYS }}"
-          export NEXT_PUBLIC_API_KEY="${{ secrets.NEXT_PUBLIC_API_KEY }}"
-          export ADMIN_USERNAME="${{ secrets.ADMIN_USERNAME }}"
-          export ADMIN_PASSWORD="${{ secrets.ADMIN_PASSWORD }}"
-          export ADMIN_PASSWORD_HASH=""
-          export JWT_SECRET="${{ secrets.JWT_SECRET }}"
-          export ALLOWED_ORIGINS="${{ secrets.ALLOWED_ORIGINS }}"
-          export NEXT_PUBLIC_API_URL=""
-          export NEXT_PUBLIC_SITE_URL="${{ secrets.NEXT_PUBLIC_SITE_URL }}"
-          
-          echo "📋 Environment variables configured (values hidden for security)"
-          
-          cd ${{ secrets.DEPLOY_PATH }}
-          
+
+          echo "📋 Environment variables configured via job-level env (values hidden for security)"
+
           echo "🔨 Esecuzione docker compose build..."
           docker compose build --no-cache
           
@@ -174,20 +177,7 @@ jobs:
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
           
           cd ${{ secrets.DEPLOY_PATH }}
-          
-          # Export environment variables for docker compose
-          export FRONTEND_API_KEYS="${{ secrets.FRONTEND_API_KEYS }}"
-          export NEXT_PUBLIC_API_KEY="${{ secrets.NEXT_PUBLIC_API_KEY }}"
-          export ADMIN_USERNAME="${{ secrets.ADMIN_USERNAME }}"
-          export ADMIN_PASSWORD="${{ secrets.ADMIN_PASSWORD }}"
-          export ADMIN_PASSWORD_HASH=""
-          export JWT_SECRET="${{ secrets.JWT_SECRET }}"
-          export ALLOWED_ORIGINS="${{ secrets.ALLOWED_ORIGINS }}"
-          export NEXT_PUBLIC_API_URL=""
-          export NEXT_PUBLIC_SITE_URL="${{ secrets.NEXT_PUBLIC_SITE_URL }}"
-          
-          cd ${{ secrets.DEPLOY_PATH }}
-          
+
           # Stop containers esistenti
           echo "🛑 Stopping running containers..."
           docker compose down


### PR DESCRIPTION
## Problema

Dopo ogni deploy in produzione, il login su `/admin/upload` restituisce **\"Invalid credentials\"**, pur con i secret GitHub invariati.

## Causa

Il workflow [deploy-production.yml](.github/workflows/deploy-production.yml) esportava i secret così:

```bash
export ADMIN_PASSWORD=\"\${{ secrets.ADMIN_PASSWORD }}\"
```

GitHub Actions sostituisce letteralmente il valore del secret nello script shell **prima** dell'esecuzione. Se la password contiene caratteri speciali (`\$`, `\"`, `` ` ``, `\\`, `!`) bash li interpreta e la variabile arriva troncata o vuota.

Con `ADMIN_PASSWORD` vuota:
1. [server/config/config.js:15](lemmario-dashboard/server/config/config.js#L15) la valuta falsy
2. [server/routes/admin.js:40-46](lemmario-dashboard/server/routes/admin.js#L40-L46) ricade sull'hash bcrypt di default, che codifica la stringa letterale `\"admin\"`
3. L'utente inserisce la password reale → mismatch → \`Invalid credentials\`

Il comportamento si ripresenta ad ogni deploy perché il build è \`--no-cache\` e il container backend viene ricreato leggendo ogni volta l'env corrotto dallo shell.

## Soluzione

Spostare tutti i secret in un blocco \`env:\` a livello di job. GitHub Actions li inietta direttamente nell'environment del processo runner (niente interpolazione shell, niente parsing di virgolette), e \`docker compose\` eredita l'env usandolo per la sostituzione \`\${VAR}\` in [docker-compose.yml](docker-compose.yml), che ha precedenza sul \`.env\` committato nel repo.

Rimossi anche i blocchi \`export ...\` duplicati negli step \"Build\" e \"Restart\" (erano la fonte del bug e ora ridondanti).

## Test plan

- [ ] Merge su \`master\` → il workflow parte automaticamente
- [ ] Verificare che il deploy si concluda con successo
- [ ] Provare login su \`https://atlante.atliteg.org/admin/upload\` con le credenziali reali → deve restituire token JWT
- [ ] (Facoltativo) \`docker compose exec backend env | grep ADMIN\` per confermare che \`ADMIN_PASSWORD\` sia il valore corretto, non vuoto