### PR TITLE
docs(phase 0-1): governance, structure, and documentation reorganization

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,85 +319,42 @@ La documentazione completa è disponibile nella cartella [`docs/`](docs/README.m
 - [Security Config](docs/security/SECURITY_CONFIG.md) - Configurazione security (Nginx, JWT, API keys)
 - [Security Executive Summary](docs/security/SECURITY_EXEC_SUMMARY.md) - Sommario esecutivo
 
-#### 🔍 Navigazione Rapida per Ruolo
-
-**Per Utenti Finali:**
-- [Quick Start](docs/guides/quick-start.md) → [User Guide](docs/guides/user-guide.md)
-
-**Per Sviluppatori:**
-- [System Architecture](docs/architecture/system-architecture.md) → [Components](docs/components/lemmario-dashboard.md) → [Quick Commands](docs/guides/quick-commands.md)
-
-**Per DevOps:**
-- [Deployment Guide](docs/guides/deployment-guide.md) → [GitHub Actions](docs/guides/github-actions.md) → [Security Config](docs/security/SECURITY_CONFIG.md)
-
 ---
 
-## 🔧 Personalizzazione
+## 📚 Documentazione
 
-- Configurazione avanzata: vedi [Vite](https://vite.dev/config/) e `tailwind.config.js`.
-- Per modifiche dati, aggiorna i file in `data/` e `public/data/`.
+Tutta la documentazione è organizzata in [`docs/`](docs/README.md):
 
----
+| Sezione | Per chi? | Start here |
+|---------|----------|-----------|
+| **Info** `[Non tecnico]` | Utenti, stakeholder | [START-HERE](docs/info/START-HERE.md) → [FAQ](docs/info/faq.md) |
+| **Architecture** `[Tecnico]` | Sviluppatori | [System Architecture](docs/architecture/system-architecture.md) |
+| **Guides** `[Tecnico]` | DevOps, Developers | [Quick Start](docs/guides/quick-start.md) → [Deployment](docs/guides/deployment-runbook.md) |
+| **Components** `[Tecnico]` | Frontend Engineers | [Lemmario Dashboard](docs/components/lemmario-dashboard.md) |
+| **Security** `[Tecnico]` | Security/DevOps | [Security Handbook](docs/security/security-handbook.md) |
+| **Project** `[Tecnico]` | Contributors | [Roadmap](docs/project/ROADMAP.md) → [Contributing](docs/project/CONTRIBUTING.md) |
 
-## 🔍 Ottimizzazione SEO
-
-<p align="center">
-	<img src="docs/seo_point.jpg" alt="Punteggio SEO" width="100%"/>
-	<br/>
-	<em>Punteggio SEO 100/100</em>
-</p>
-
-Il progetto implementa le seguenti ottimizzazioni SEO per migliorare la visibilità sui motori di ricerca:
-
-### Metadata e Tag Essenziali
-
-- **Title e Description**: Tag ottimizzati con parole chiave rilevanti
-- **Open Graph**: Tag per condivisione ottimale su social media (Facebook, LinkedIn)
-- **Twitter Cards**: Metadata specifici per Twitter
-- **Favicon e Apple Icons**: Icone per tutti i dispositivi e piattaforme
-- **Canonical URL**: Prevenzione contenuti duplicati
-
-### Contenuto Strutturato
-
-- **Schema.org JSON-LD**: Markup strutturato per motori di ricerca (tipo: WebSite, SearchAction, Organization)
-- **Sitemap XML**: Generazione automatica per indicizzazione completa
-- **Robots.txt**: Configurazione crawling ottimale
-
-### Performance e Accessibilità
-
-- **Viewport Meta**: Ottimizzazione per dispositivi mobili
-- **Theme Color**: Integrazione con browser mobile
-- **Alt Text**: Descrizioni per tutte le immagini (inclusi loghi partner)
-
-### Partner Istituzionali
-
-Il footer include i loghi dei partner con markup semantico appropriato:
-
-- Università Roma Tre
-- Università per Stranieri di Siena
-- DH Unica (Digital Humanities, Università di Cagliari)
-- AtLiTeG Project
-
-**Punteggio SEO**: 100/100
-
-<p align="right">(<a href="#readme-top">torna su</a>)</p>
+→ [**Indice Completo (docs/README.md)**](docs/README.md)
 
 ---
 
 <a name="faq"></a>
 ## ❓ FAQ
 
-**Come posso contribuire?**  
-Consulta la guida [CONTRIBUTING](docs/project/CONTRIBUTING.md) e apri una issue o una pull request.
+**Come iniziare a usare ATLITEG?**  
+→ [Guida Rapida (3 min)](docs/info/START-HERE.md) oppure [User Guide completa](docs/guides/user-guide.md)
 
-**Come risolvo problemi di caricamento dati?**  
-Vedi [Upload Troubleshooting](docs/guides/upload-troubleshooting.md).
+**Come posso contribuire al progetto?**  
+→ [Linee guida Contributing](docs/project/CONTRIBUTING.md)
 
 **Dove trovo la documentazione tecnica?**  
-Tutta la documentazione è in [docs/](docs/README.md).
+→ [Indice Documentazione Completo](docs/README.md) (Architecture, Guides, Components, Security)
 
-**Come verifico la salute del deployment?**  
-Controlla i log Docker e lo stato del runner GitHub Actions.
+**Come aggiorno i dati?**  
+→ [Data Operations Runbook](docs/guides/data-operations.md)
+
+**Come faccio il deploy?**  
+→ [Deployment Runbook](docs/guides/deployment-runbook.md)
 
 ---
 

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -1,0 +1,175 @@
+# Governance Documentazione Atliteg
+
+**Data**: 14 giugno 2026  
+**Versione**: 1.0
+
+## Policy Stato Documento
+
+Ogni documento deve essere taggato esplicitamente con **UNO** di questi stati:
+
+| Stato | Significato | Aggiornamento | Chi legge |
+|-------|-------------|--------------|-----------|
+| `[OPERATIVO]` | Riflette l'architettura/workflow corrente | Entro 2 settimane da changes critici | Tutti |
+| `[TECNICO]` | Documento di design/proposal tecnico, non dipende da runtime | Quando decision cambia | Sviluppatori |
+| `[STORICO]` | Documento decisionale/report passato, non operativo | No, referenza sola | Ricercatori/Archivisti |
+
+**Regola binaria**: Se un documento non è taggato, è considerato **OBSOLETO** e deve essere rimosso o taggato.
+
+---
+
+## Ownership per Cartella
+
+| Cartella | Owner | Backup | Policy |
+|----------|-------|--------|--------|
+| `docs/architecture/` | Tech Lead | Maintainer | Review PR: Design + Code alignment check |
+| `docs/guides/` | DevOps/Tech Lead | Tech Lead | Review PR: Commands tested + Links verified |
+| `docs/components/` | Frontend Lead | Tech Lead | Review PR: Code snippet consistency |
+| `docs/project/` | Project Manager | Tech Lead | Review PR: Dates + Status consistency |
+| `docs/security/` | Security Owner | Tech Lead | Review PR: Threat model + Config checks |
+| `docs/info/` | UX Writer | Tech Lead | Review PR: Language clarity + No jargon |
+| `docs/archive/` | Historian | Tech Lead | Review PR: Metadata + Search keywords |
+
+---
+
+## Una Fonte Canonica Per Tema
+
+**Principio**: Ogni tema ha **UN SOLO** documento operativo autorità.
+
+### Mappa Temi → Documento Canonico
+
+| Tema | Documento Canonico | Alternati | Azione |
+|------|-------------------|-----------|--------|
+| Architettura sistema | `docs/architecture/system-architecture.md` | `docs/components/lemmario-dashboard.md` (dettagli frontend) | system-architecture è master; frontend rinvia a essa |
+| Deployment | `docs/guides/deployment-runbook.md` | `DEPLOY_MULTIDOMAIN.md` (legacy) | Mantenere runbook unico; DEPLOY_MULTIDOMAIN rinvia |
+| Data operations | `docs/guides/data-operations.md` | `CSV_UPLOAD_GUIDE.md`, `data-sync.md` (legacy) | Data-operations è master; altri rinviano |
+| Testing | `docs/guides/testing.md` | `test-checklist.md` (legacy) | Testing è master; checklist è appendice |
+| Security | `docs/security/security-handbook.md` | `DATA_SECURITY.md`, `SECURITY_CONFIG.md` (legacy) | Handbook è master; altri archiviati |
+| Feature regioni | `docs/guides/regions-feature.md` | `region-codes.md` (legacy) | Regions-feature è master; codes è appendice |
+| API Backend | `docs/architecture/backend-api-design.md` | `docs/guides/api-reference.md` (legacy) | Backend-api-design è master; reference è quickref |
+| Quick Start | `docs/guides/quick-start.md` | `lemmario-dashboard/QUICK_START.md` (legacy) | Unico canonico; local file rinvia |
+
+---
+
+## Convenzioni Naming
+
+### Branch
+
+```
+docs/<phase-or-theme>-phase<X>-Y
+docs/governance-structure-phase0-1
+docs/critical-fixes-phase2
+docs/data-operations-accorpamento-phase3
+```
+
+### Commit
+
+```
+docs: <tema> — <descrizione sintetica>
+
+es:
+docs: governance and structure — add governance.md, restructure readme indexes
+docs: critical fixes — update system-architecture, deployment, contributing
+```
+
+### PR Title
+
+```
+docs(phase-X): <descrizione>
+
+es:
+docs(phase 0-1): governance, structure, and documentation reorganization
+docs(phase 2): critical documentation updates
+```
+
+---
+
+## Linee Guida Redazione
+
+### Header Obbligatorio per Documenti Operativi
+
+```markdown
+---
+status: [OPERATIVO|TECNICO|STORICO]
+last-updated: YYYY-MM-DD
+owner: <name/role>
+---
+
+# Titolo Documento
+```
+
+### Tagging Link in Indice
+
+```markdown
+- [User Guide](guides/user-guide.md) `[Non tecnico]` — Manuale utente
+- [System Architecture](architecture/system-architecture.md) `[Tecnico]` — Architettura
+- [CI/CD Fix Jan 2026](../archive/ci-cd-fix-jan2026.md) `[STORICO]` — Report incidente
+```
+
+### Link Rotti: Policy
+
+- **Discovery**: Link checker automatico su PR (pre-merge)
+- **Fix**: PR author deve correggere prima di merge
+- **Azioni**:
+  - Link target non esiste → Creare target o rimuovere link
+  - Link errato → Correggere percorso
+  - Documento mosso → Aggiornare link ovunque
+
+---
+
+## Ciclo di Vita Documento
+
+```
+BOZZA → REVIEW (24h) → OPERATIVE/STAGING → [AGING CHECK ogni 6 mesi] → OBSOLETO/ARCHIVE
+```
+
+### Aging Check (ogni 6 mesi)
+
+- Seleziona docs con `[OPERATIVO]`
+- Valuta: "Codice/runtime è cambiato significativamente?"
+  - Sì → Update o `[DEPRECATO]`
+  - No → Estendi scadenza
+- Registra data aggiornamento in header
+
+---
+
+## Governance Review Board (Virtuale)
+
+| Role | Cadenza | Scope |
+|------|---------|-------|
+| Tech Lead | 1x settimana | Architecture + Breaking changes |
+| DevOps | 1x settimana | Guides + Deployment |
+| Security | 1x mese | Security + Secrets policy |
+| UX Writer | Ad hoc | Info + Language clarity |
+
+---
+
+## Checklist Pre-Merge (obbligatorio)
+
+- [ ] Documento taggato con status
+- [ ] Header YAML con last-updated + owner
+- [ ] Tutti link verificati (no link rotti)
+- [ ] No doppioni con documento canonico (o rinvia)
+- [ ] Linguaggio coerente con audience (tecnico/non tecnico)
+- [ ] Se [OPERATIVO], comandi/screenshot verificati
+- [ ] Se [STORICO], marcato esplicitamente in intro
+
+---
+
+## Accesso e Permessi
+
+| Azione | Chi | Approvazione |
+|--------|-----|-------------|
+| Merge PR docs | Author + 1 reviewer | Tech Lead final approval |
+| Spostare in archive | Author | Tech Lead (no PR needed se solo archivio) |
+| Cancellare documento | Author | Tech Lead + Project Manager |
+| Creare nuova cartella | Maintainer | Tech Lead (inline decision) |
+
+---
+
+## Obiettivi Annuali
+
+- 0 link rotti nell'indice (check settimanale)
+- 100% documenti taggati
+- Nessun documento [OPERATIVO] >6 mesi senza review
+- Percorso non tecnico completo (3 click max da `README.md`)
+- Archive > 20 documenti storici ben catalogati

--- a/docs/PIANO_RIORDINO_DOCUMENTAZIONE.md
+++ b/docs/PIANO_RIORDINO_DOCUMENTAZIONE.md
@@ -1,0 +1,241 @@
+# Piano di riordino documentazione ATLITEG
+
+Data: 2026-04-15
+Branch analizzato: `master`
+Ambito: documentazione Markdown del repository (esclusi file di istruzioni per agenti AI)
+
+## Obiettivo
+
+Rendere la documentazione:
+- chiara per figure non tecniche
+- affidabile per figure tecniche
+- non ridondante
+- manutenibile nel tempo con una fonte unica per ogni tema
+
+## Legenda stato aggiornamento
+
+- `Aggiornato`: coerente con codice e operativita corrente
+- `Parzialmente aggiornato`: utile ma con sezioni datate, incomplete o link da correggere
+- `Obsoleto`: non coerente con architettura/comandi/flow correnti
+- `Difficile da verificare`: documento storico o strategico, non direttamente validabile sul runtime
+
+## Valutazione per documento
+
+### 1) Root e indice principale
+
+| Documento | Stato | Superfluo / Doppioni | Documenti simili | Azione proposta |
+|---|---|---|---|---|
+| `README.md` | Parzialmente aggiornato | Parziale doppione indice docs | `docs/README.md` | Snellire a landing + link a percorsi Utenti/Tecnici |
+| `DEPLOY_MULTIDOMAIN.md` | Parzialmente aggiornato | Doppione parziale | `docs/guides/multi-domain-deployment.md` | Tenere un solo canonico e trasformare l'altro in redirect |
+
+### 2) Meta-documentazione in `docs/`
+
+| Documento | Stato | Superfluo / Doppioni | Documenti simili | Azione proposta |
+|---|---|---|---|---|
+| `docs/README.md` | Parzialmente aggiornato | No | `README.md` | Mantenere come indice ufficiale, con etichette Operativo/Storico |
+| `docs/ANALISI_DOCUMENTAZIONE.md` | Difficile da verificare | Parzialmente superfluo (storico) | `docs/TABELLA_STATO_DOCUMENTAZIONE.md` | Spostare in `docs/archive/` |
+| `docs/IMPLEMENTAZIONE_COMPLETATA.md` | Difficile da verificare | Parzialmente superfluo (storico) | `docs/SOMMARIO_AGGIORNAMENTO_DOCS.md` | Spostare in `docs/archive/` |
+| `docs/SOMMARIO_AGGIORNAMENTO_DOCS.md` | Difficile da verificare | Parzialmente superfluo (storico) | `docs/IMPLEMENTAZIONE_COMPLETATA.md` | Spostare in `docs/archive/` |
+| `docs/TABELLA_STATO_DOCUMENTAZIONE.md` | Parzialmente aggiornato | Doppione parziale audit | `docs/ANALISI_DOCUMENTAZIONE.md` | Integrare nel nuovo piano, poi archiviare |
+
+### 3) Architettura (`docs/architecture/`)
+
+| Documento | Stato | Superfluo / Doppioni | Documenti simili | Azione proposta |
+|---|---|---|---|---|
+| `docs/architecture/README.md` | Parzialmente aggiornato | No | `docs/README.md` | Aggiornare indice locale con file realmente operativi |
+| `docs/architecture/system-architecture.md` | Obsoleto | No | `docs/components/lemmario-dashboard.md` | Riscrivere come single source of truth architetturale |
+| `docs/architecture/backend-api-design.md` | Parzialmente aggiornato | Doppione parziale API | `docs/guides/api-reference.md` | Mantenere tecnico, eliminare conflitti e link rotti |
+| `docs/architecture/dataset-specification.md` | Difficile da verificare | No | guide upload/regioni | Verifica campi effettivi e semplificazione |
+| `docs/architecture/requirements.md` | Parzialmente aggiornato | Doppione parziale roadmap | `docs/project/ROADMAP.md` | Tenere requisiti stabili, togliere riferimenti legacy |
+| `docs/architecture/performance.md` | Parzialmente aggiornato | Doppione parziale runbook tecnico | guide deployment/testing | Aggiornare comandi reali e metriche minime attese |
+| `docs/architecture/motion-system.md` | Parzialmente aggiornato | Doppione parziale UX tecnica | `docs/architecture/dynamic-graphics.md` | Accorpare in una sola guida tecnica UI motion |
+| `docs/architecture/dynamic-graphics.md` | Difficile da verificare | Doppione parziale motion | `docs/architecture/motion-system.md` | Accorpare o archiviare se solo progettuale |
+
+### 4) Componenti (`docs/components/`)
+
+| Documento | Stato | Superfluo / Doppioni | Documenti simili | Azione proposta |
+|---|---|---|---|---|
+| `docs/components/lemmario-dashboard.md` | Parzialmente aggiornato | Doppione parziale architettura | `docs/architecture/system-architecture.md` | Tenere come guida tecnica frontend |
+| `docs/components/dashboard-features.md` | Parzialmente aggiornato | Doppione parziale user guide | `docs/guides/user-guide.md` | Ridurre e mantenere solo dettagli tecnici |
+| `docs/components/map-clustering-behavior.md` | Aggiornato | No | `docs/components/popup-system.md` | Mantenere |
+| `docs/components/popup-system.md` | Parzialmente aggiornato | Doppione parziale map | `docs/components/map-clustering-behavior.md` | Aggiornare e collegare alla doc map |
+| `docs/components/timeline-component.md` | Parzialmente aggiornato | Doppione parziale UX | `docs/guides/user-guide.md` | Mantenere tecnico, ridurre descrizioni utente |
+| `docs/components/filters.md` | Parzialmente aggiornato | Doppione parziale UX | `docs/guides/user-guide.md` | Integrare in guida UI tecnica o user guide |
+| `docs/components/header.md` | Parzialmente aggiornato | Possibile superfluo | `docs/components/dashboard-features.md` | Accorpare |
+| `docs/components/search-bar.md` | Parzialmente aggiornato | Doppione parziale UX | `docs/guides/user-guide.md` | Accorpare |
+| `docs/components/alphabetical-index.md` | Parzialmente aggiornato | Doppione parziale UX | `docs/guides/user-guide.md` | Accorpare |
+| `docs/components/lemma-detail.md` | Parzialmente aggiornato | Doppione parziale UX | `docs/guides/user-guide.md` | Accorpare |
+| `docs/components/metrics-summary.md` | Parzialmente aggiornato | Doppione parziale UX | `docs/components/dashboard-features.md` | Accorpare |
+
+### 5) Guide (`docs/guides/`)
+
+| Documento | Stato | Superfluo / Doppioni | Documenti simili | Azione proposta |
+|---|---|---|---|---|
+| `docs/guides/quick-start.md` | Obsoleto | Doppione quick start | `lemmario-dashboard/QUICK_START.md` | Sostituire con quick start unico aggiornato |
+| `docs/guides/user-guide.md` | Parzialmente aggiornato | No | component docs UI | Mantenere per non tecnici, semplificare linguaggio |
+| `docs/guides/nota-componente-tecnica-atlante.md` | Parzialmente aggiornato | Doppione divulgativo parziale | user guide + architecture | Tenere come materiale divulgativo separato |
+| `docs/guides/deployment-guide.md` | Obsoleto | Doppione parziale deploy | `docs/guides/github-actions.md` | Riscrivere runbook deploy reale |
+| `docs/guides/testing.md` | Parzialmente aggiornato | Doppione parziale test | `docs/guides/test-checklist.md` | Unificare in un unico documento test |
+| `docs/guides/test-checklist.md` | Parzialmente aggiornato | Doppione parziale test | `docs/guides/testing.md` | Unificare in un unico documento test |
+| `docs/guides/github-actions.md` | Parzialmente aggiornato | Doppione parziale CI | `docs/guides/github-actions-secrets.md` | Tenere, ma separare setup vs segreti |
+| `docs/guides/github-actions-secrets.md` | Parzialmente aggiornato | No | `docs/guides/github-actions.md` | Tenere come appendice sicurezza CI |
+| `docs/guides/multi-domain-deployment.md` | Parzialmente aggiornato | Doppione parziale | `DEPLOY_MULTIDOMAIN.md` | Tenere come canonico (consigliato) |
+| `docs/guides/ci-cd-fix-jan2026.md` | Difficile da verificare | Storico | `docs/project/CHANGELOG.md` | Spostare in `docs/archive/incidenti/` |
+| `docs/guides/quick-commands.md` | Parzialmente aggiornato | Doppione parziale quick start | quick start, deployment | Tenere come cheat sheet tecnico |
+| `docs/guides/api-reference.md` | Obsoleto | Doppione/in conflitto | `docs/architecture/backend-api-design.md` | Riscrivere o inglobare nel backend-api-design |
+| `docs/guides/CSV_UPLOAD_GUIDE.md` | Parzialmente aggiornato | Doppione upload | `upload-refresh-guide.md`, `upload-troubleshooting.md` | Unificare in runbook Data Operations |
+| `docs/guides/upload-refresh-guide.md` | Aggiornato | Doppione upload | `CSV_UPLOAD_GUIDE.md` | Unificare in runbook Data Operations |
+| `docs/guides/upload-troubleshooting.md` | Aggiornato | Doppione upload | `CSV_UPLOAD_GUIDE.md` | Unificare in runbook Data Operations |
+| `docs/guides/data-sync.md` | Parzialmente aggiornato | Doppione parziale data ops | guide upload | Integrare nel runbook Data Operations |
+| `docs/guides/region-codes.md` | Parzialmente aggiornato | Doppione parziale feature regioni | `docs/guides/regions-feature.md` | Accorpare in appendice tecnica |
+| `docs/guides/regions-feature.md` | Aggiornato | No | `docs/guides/region-codes.md` | Mantenere |
+| `docs/guides/backend-only-test-report.md` | Parzialmente aggiornato | Storico | testing docs | Archiviare come report storico |
+| `docs/guides/seo-implementation.md` | Parzialmente aggiornato | Doppione parziale README | `README.md` | Mantenere tecnico, ridurre parti introduttive |
+
+### 6) Improvement (`docs/improvement/`)
+
+| Documento | Stato | Superfluo / Doppioni | Documenti simili | Azione proposta |
+|---|---|---|---|---|
+| `docs/improvement/MAPCN_README.md` | Difficile da verificare | No (storico decisionale) | altri `MAPCN_*` | Spostare in area research/archive |
+| `docs/improvement/MAPCN_INTEGRATION_ANALYSIS.md` | Difficile da verificare | No (storico decisionale) | altri `MAPCN_*` | Spostare in area research/archive |
+| `docs/improvement/MAPCN_INTEGRATION_SUMMARY.md` | Difficile da verificare | Doppione summary | `MAPCN_INTEGRATION_ANALYSIS.md` | Mantenere solo 1 summary + 1 analisi |
+| `docs/improvement/MAPCN_CODE_COMPARISON.md` | Difficile da verificare | No | altri `MAPCN_*` | Archiviare |
+| `docs/improvement/MAPCN_DECISION_TREE.md` | Difficile da verificare | Doppione decisionale | `MAPCN_INTEGRATION_SUMMARY.md` | Archiviare o accorpare |
+| `docs/improvement/MAPCN_POC_EXAMPLE.md` | Difficile da verificare | No | altri `MAPCN_*` | Archiviare |
+
+### 7) Project (`docs/project/`)
+
+| Documento | Stato | Superfluo / Doppioni | Documenti simili | Azione proposta |
+|---|---|---|---|---|
+| `docs/project/ROADMAP.md` | Difficile da verificare | Doppione parziale requisiti | `docs/architecture/requirements.md` | Mantenere come pianificazione |
+| `docs/project/CHANGELOG.md` | Parzialmente aggiornato | No | `docs/guides/ci-cd-fix-jan2026.md` | Mantenere, con note legacy esplicite |
+| `docs/project/CONTRIBUTING.md` | Obsoleto | Doppione setup | quick start/development docs | Riscrivere su workflow reale |
+| `docs/project/bugs-and-features.md` | Difficile da verificare | Doppione backlog | roadmap/feedback | Mantenere solo se usato attivamente |
+| `docs/project/feedback_analysis_20251224.md` | Difficile da verificare | Storico | bugs-and-features | Archiviare |
+| `docs/project/copilot-instructions.md` | Escluso (AI-only) | Superfluo per docs utente | `.github/copilot-instructions.md` | Tenere fuori dall'indice pubblico |
+
+### 8) Security (`docs/security/`)
+
+| Documento | Stato | Superfluo / Doppioni | Documenti simili | Azione proposta |
+|---|---|---|---|---|
+| `docs/security/DATA_SECURITY.md` | Parzialmente aggiornato | Doppione parziale security setup | `SECURITY_CONFIG.md` | Accorpare in Security Handbook |
+| `docs/security/SECURITY_CONFIG.md` | Parzialmente aggiornato | Doppione parziale security setup | `DATA_SECURITY.md` | Tenere come base tecnica |
+| `docs/security/SECURITY_EXEC_SUMMARY.md` | Parzialmente aggiornato | Doppione summary | altri security docs | Mantenere versione breve non tecnica |
+
+### 9) Altri Markdown utili fuori `docs/`
+
+| Documento | Stato | Superfluo / Doppioni | Documenti simili | Azione proposta |
+|---|---|---|---|---|
+| `lemmario-dashboard/QUICK_START.md` | Obsoleto | Doppione quick start | `docs/guides/quick-start.md` | Eliminare o trasformare in link al quick start canonico |
+| `scripts/README.md` | Parzialmente aggiornato | No | region/data docs | Aggiornare elenco script reali |
+
+## Aree non coperte (gap)
+
+## 1) Area informativa (non tecnica)
+
+- Manca una guida corta "inizia da qui" per utenti finali
+- Manca una FAQ in linguaggio semplice
+- Manca un processo editoriale dati (chi aggiorna, chi valida, chi pubblica)
+
+## 2) Area tecnica (per tecnici)
+
+- Manca una fonte unica su architettura reale aggiornata
+- Manca un runbook unico deploy + rollback + incident response
+- Manca una matrice centralizzata versioni/runtime/env
+
+## Piano di riordino operativo
+
+### Fase 0 - Governance (Priorita: Alta)
+
+- Definire ownership per cartella docs (`owner` tecnico + owner contenuti)
+- Definire policy stato documento: Operativo / Tecnico / Storico
+- Definire regola "una fonte canonica per tema"
+
+### Fase 1 - Stabilizzazione indice (Priorita: Alta)
+
+- Rifare `docs/README.md` come indice ufficiale
+- Ridurre `README.md` root a landing sintetica
+- Taggare ogni link con etichetta: `[Non tecnico]`, `[Tecnico]`, `[Storico]`
+
+### Fase 2 - Correzioni critiche (Priorita: Alta)
+
+Aggiornare subito i documenti critici:
+- `docs/architecture/system-architecture.md`
+- `docs/guides/deployment-guide.md`
+- `docs/guides/api-reference.md`
+- `docs/project/CONTRIBUTING.md`
+- `docs/guides/quick-start.md`
+
+### Fase 3 - Accorpamenti (Priorita: Media)
+
+- Multi-domain: 1 solo documento canonico
+- Data operations: unificare upload + refresh + troubleshooting + data-sync
+- Testing: unificare `testing.md` + `test-checklist.md`
+- Security: accorpare `DATA_SECURITY.md` e `SECURITY_CONFIG.md` con summary separata
+
+### Fase 4 - Percorso non tecnico (Priorita: Media)
+
+Creare `docs/info/`:
+- `docs/info/START-HERE.md` (non tecnico)
+- `docs/info/guida-utente-breve.md` (non tecnico)
+- `docs/info/faq.md` (non tecnico)
+
+Ogni documento tecnico dovra avere intestazione esplicita:
+- "Questa documentazione e tecnica ed e destinata a sviluppatori/devops."
+
+### Fase 5 - Archivio storico (Priorita: Bassa)
+
+- Creare `docs/archive/`
+- Spostare report/audit storici e documenti di decisione passata
+- Aggiungere banner iniziale: "Documento storico, non operativo"
+
+## Struttura finale consigliata
+
+```text
+docs/
+  README.md
+  info/
+    START-HERE.md
+    guida-utente-breve.md
+    faq.md
+  architecture/
+    system-architecture.md
+    backend-api-design.md
+    dataset-specification.md
+  guides/
+    quick-start.md
+    deployment-runbook.md
+    data-operations.md
+    testing.md
+    github-actions.md
+    multi-domain-deployment.md
+  components/
+    map-clustering-behavior.md
+    popup-system.md
+    timeline-component.md
+    lemmario-dashboard.md
+  security/
+    security-handbook.md
+    security-exec-summary.md
+  project/
+    ROADMAP.md
+    CHANGELOG.md
+    CONTRIBUTING.md
+  archive/
+    ...
+```
+
+## Piano temporale suggerito
+
+- Settimana 1: Fasi 0-1 (governance + indice)
+- Settimana 2: Fase 2 (fix critici)
+- Settimana 3: Fase 3 (accorpamenti)
+- Settimana 4: Fasi 4-5 (percorso non tecnico + archivio)
+
+## Criteri di accettazione
+
+- 0 link rotti nell'indice principale
+- ogni tema ha 1 documento canonico
+- percorso non tecnico completo in massimo 3 click da `README.md`
+- documenti tecnici marcati chiaramente come tecnici
+- documenti storici separati dall'operativo

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,84 +1,112 @@
+---
+status: "[OPERATIVO]"
+last-updated: 2026-06-14
+owner: Tech Lead
+---
+
 # 📚 Indice Documentazione Atliteg
 
-**Versione**: 2.0  
-**Ultima Modifica**: 17 Gennaio 2026  
-**Stato**: Aggiornato - Consolidamento Completato
+**Versione**: 3.0 (Governanza)  
+**Ultima Modifica**: 14 Giugno 2026  
+**Stato**: Aggiornato - Governance Stabilita
 
 Benvenuto nella documentazione ufficiale del progetto Atliteg. Qui troverai tutte le risorse necessarie per comprendere, sviluppare e mantenere il progetto.
+
+**Legenda**:  
+`[Non tecnico]` — Accessibile senza background tech  
+`[Tecnico]` — Richiede conoscenza tecnica  
+`[STORICO]` — Documento di riferimento, non operativo
+
+---
 
 ## 🏗️ Architecture
 Documenti di design, specifiche tecniche e requisiti del sistema.
 
-- [System Architecture](architecture/system-architecture.md) - Panoramica dell'architettura del sistema
-- [Backend API Design](architecture/backend-api-design.md) - Design e implementazione API backend
-- [Dataset Specification](architecture/dataset-specification.md) - Specifiche dei dati e formati
-- [Dynamic Graphics](architecture/dynamic-graphics.md) - Dettagli sugli effetti grafici e visualizzazioni
-- [Motion System](architecture/motion-system.md) - Sistema di animazioni e transizioni
-- [Performance](architecture/performance.md) - Analisi e ottimizzazione delle performance
-- [Requirements](architecture/requirements.md) - Requisiti funzionali e non funzionali
+- [System Architecture](architecture/system-architecture.md) `[Tecnico]` — Panoramica completa architettura; **SINGLE SOURCE OF TRUTH**
+- [Backend API Design](architecture/backend-api-design.md) `[Tecnico]` — Design e implementazione API backend
+- [Dataset Specification](architecture/dataset-specification.md) `[Tecnico]` — Specifiche dati e formati
+- [Requirements](architecture/requirements.md) `[Tecnico]` — Requisiti funzionali e non funzionali
+- [Performance](architecture/performance.md) `[Tecnico]` — Analisi e ottimizzazione performance
+
+**Archivio**: Motion system e Dynamic graphics → [archive/](../archive/)
 
 ## 📘 Guides
 Manuali utente, guide per sviluppatori, setup e procedure operative.
 
-### Guide Principali
-- [Quick Start](guides/quick-start.md) - Guida rapida per iniziare
-- [User Guide](guides/user-guide.md) - Manuale utente completo
-- [Nota Componente Tecnica Atlante](guides/nota-componente-tecnica-atlante.md) - Sintesi divulgativa della componente tecnica per presentazioni e seminari
-- [Nota Componente Tecnica Atlante HTML](guides/nota-componente-tecnica-atlante.html) - Versione presentabile in stile slide con diagramma architetturale e focus su UI e filtri
-- [Deployment Guide](guides/deployment-guide.md) - Guida al deployment in produzione
-- [Testing Guide](guides/testing.md) - Guida all'esecuzione dei test
-- [Test Checklist](guides/test-checklist.md) - Checklist per il testing manuale (189 test)
+### 🚀 Getting Started
+- [Quick Start](guides/quick-start.md) `[Non tecnico]` — Guida rapida per iniziare (source unica)
+- [User Guide](guides/user-guide.md) `[Non tecnico]` — Manuale completo per utenti
 
-### Guide Tecniche
-- [GitHub Actions](guides/github-actions.md) - Configurazione CI/CD
-- [SEO Implementation](guides/seo-implementation.md) - Strategia SEO/AEO/GEO completa
-- [API Reference](guides/api-reference.md) - Riferimento API
-- [Quick Commands](guides/quick-commands.md) - Lista comandi frequenti
-- [Region Codes](guides/region-codes.md) - Guida ai codici regionali ISTAT
+### ⚙️ Deployment & Operations (Runbook)
+- [Deployment Runbook](guides/deployment-runbook.md) `[Tecnico]` — Procedura deploy, rollback, incident response (**canonico**)
+- [Multi-Domain Deployment](guides/multi-domain-deployment.md) `[Tecnico]` — Setup DNS e certificate multi-dominio
+- [GitHub Actions](guides/github-actions.md) `[Tecnico]` — Configurazione CI/CD e secrets
+- [Data Operations](guides/data-operations.md) `[Tecnico]` — Upload CSV, refresh, troubleshooting (**canonico**)
 
-### Guide Dati e Upload
-- [Data Sync](guides/data-sync.md) - Procedure di sincronizzazione dati
-- [CSV Upload Guide](guides/CSV_UPLOAD_GUIDE.md) - Guida caricamento CSV
-- [Upload Refresh Guide](guides/upload-refresh-guide.md) - Procedura refresh dati
-- [Upload Troubleshooting](guides/upload-troubleshooting.md) - Risoluzione problemi upload
+### 🧪 Testing & QA
+- [Testing Guide](guides/testing.md) `[Tecnico]` — Guida esecuzione test (**canonico**)
+- [Quick Commands](guides/quick-commands.md) `[Tecnico]` — Cheat sheet comandi frequenti
 
-### Feature Guides
-- [Regions Feature](guides/regions-feature.md) - Integrazione codici regionali ISTAT e visualizzazione confini
+### 📚 Reference & Features
+- [API Reference](guides/api-reference.md) `[Tecnico]` — Quickref API (→ backend-api-design per dettagli)
+- [Regions Feature](guides/regions-feature.md) `[Tecnico]` — Codici ISTAT e visualizzazione confini
+- [SEO Implementation](guides/seo-implementation.md) `[Tecnico]` — Strategia SEO/AEO/GEO
+
+### 🎓 Divulgazione Tecnica
+- [Nota Componente Tecnica Atlante](guides/nota-componente-tecnica-atlante.md) `[Non tecnico]` — Sintesi per presentazioni e seminari
+- [Nota Componente Tecnica Atlante HTML](guides/nota-componente-tecnica-atlante.html) `[Non tecnico]` — Versione slide con diagrammi
 
 ## 🧩 Components
-Documentazione specifica dei componenti del sistema.
+Documentazione tecnica dei componenti del sistema.
 
-### Componenti Principali
-- [Lemmario Dashboard](components/lemmario-dashboard.md) - Documentazione tecnica completa del frontend Next.js
-- [Dashboard Features](components/dashboard-features.md) - Funzionalità e componenti della dashboard
-- [Map Clustering Behavior](components/map-clustering-behavior.md) - Clustering sulla mappa geografica
-- [Timeline Component](components/timeline-component.md) - Componente timeline storica
-- [Popup System](components/popup-system.md) - Sistema popup mappa con accordion
+### Frontend Architecture
+- [Lemmario Dashboard](components/lemmario-dashboard.md) `[Tecnico]` — Documentazione tecnica Next.js/React frontend
+- [Map Clustering Behavior](components/map-clustering-behavior.md) `[Tecnico]` — Clustering e visualizzazione mappa Leaflet
+- [Timeline Component](components/timeline-component.md) `[Tecnico]` — Componente timeline storica
+- [Popup System](components/popup-system.md) `[Tecnico]` — Sistema popup mappa con accordion
 
-### Componenti UI
-- [Header](components/header.md) - Header con navigazione e branding
-- [Filters](components/filters.md) - Filtri categoria e periodo con multi-select
-- [Search Bar](components/search-bar.md) - Ricerca autocompletante con debounce
-- [Alphabetical Index](components/alphabetical-index.md) - Indice alfabetico A-Z
-- [Lemma Detail](components/lemma-detail.md) - Pannello dettaglio forme e occorrenze
-- [Metrics Summary](components/metrics-summary.md) - Metriche aggregate dashboard
+**UI Components**: [Header](components/header.md), [Filters](components/filters.md), [Search](components/search-bar.md), [Alphabetical Index](components/alphabetical-index.md), [Lemma Detail](components/lemma-detail.md), [Metrics](components/metrics-summary.md) → Consolidati in `lemmario-dashboard.md`
+
+**Dashboard Features**: [Dashboard Features](components/dashboard-features.md) → Consolidato in user guide + lemmario-dashboard.md
 
 ## ⚙️ Project
-Meta-documentazione del progetto e roadmap.
+Meta-documentazione del progetto, roadmap e governance.
 
-- [Roadmap](project/ROADMAP.md) - Piano sviluppo futuro (37 items, 6 release)
-- [Changelog](project/CHANGELOG.md) - Registro delle modifiche
-- [Contributing](project/CONTRIBUTING.md) - Linee guida per contribuire
-- [Bugs and Features](project/bugs-and-features.md) - Tracking di bug e funzionalità
-- [Copilot Instructions](project/copilot-instructions.md) - Istruzioni per l'AI assistant
-- [Feedback Analysis](project/feedback_analysis_20251224.md) - Analisi feedback utenti
+- [Governance Documentation](GOVERNANCE.md) `[Tecnico]` — Policy stato, ownership, naming conventions
+- [Roadmap](project/ROADMAP.md) `[Tecnico]` — Piano sviluppo futuro (37 items, 6 release)
+- [Changelog](project/CHANGELOG.md) `[Tecnico]` — Registro modifiche (con note legacy)
+- [Contributing](project/CONTRIBUTING.md) `[Tecnico]` — Workflow sviluppo e PR standards
+
+**Archivio**: Feedback analysis, bugs tracking → [archive/project/](../archive/)
 
 ## 🔒 Security
 Documentazione relativa a sicurezza e protezione dati.
 
-- [Data Security](security/DATA_SECURITY.md) - Setup protezione dati e file sensibili
-- [Security Config](security/SECURITY_CONFIG.md) - Configurazione security (Nginx, JWT, API keys)
-- [Security Executive Summary](security/SECURITY_EXEC_SUMMARY.md) - Sommario esecutivo per stakeholder
+- [Security Handbook](security/security-handbook.md) `[Tecnico]` — Guida completa security (**canonico**)
+- [Security Executive Summary](security/SECURITY_EXEC_SUMMARY.md) `[Non tecnico]` — Riepilogo per stakeholder non tecnici
+
+**Archivio**: Data Security (legacy), Security Config (legacy) → [archive/security/](../archive/)
+
+---
+
+## 💡 Info — Percorso Non Tecnico
+Per utenti, stakeholder e decisori senza background tecnico.
+
+- [Start Here](info/START-HERE.md) `[Non tecnico]` — Da qui iniziare (landing rapida)
+- [Guida Utente Breve](info/guida-utente-breve.md) `[Non tecnico]` — Come usare ATLITEG (3 min read)
+- [FAQ](info/faq.md) `[Non tecnico]` — Risposte a domande frequenti
+
+---
+
+## 📦 Archive — Documenti Storici
+Decisioni passate, report di incidenti, design obsoleti.
+
+Tutti i documenti qui sono taggati `[STORICO]` e non operativi.
+
+- [Analysis & Planning](archive/) `[STORICO]` — Analisi storiche (es. MAPCN, feedback analysis)
+- [CI/CD Incidents](archive/ci-cd-fix-jan2026.md) `[STORICO]` — Incident report 2026
+- [Security Legacy](archive/security/) `[STORICO]` — Config e design security passati
+- [Project Legacy](archive/project/) `[STORICO]` — Feedback, bugs tracking, copilot instructions
 
 ---
 
@@ -90,6 +118,13 @@ Documentazione relativa a sicurezza e protezione dati.
 - ✅ Creati 10 nuovi documenti (ROADMAP + 6 componenti + 3 feature docs)
 - ✅ Copertura componenti: 3 → 10 (333% incremento)
 - ✅ Documenti totali: 62 → ~48 (-23%)
+
+**14 Giugno 2026 - v3.0 (Governance)**: Stabilizzazione governance
+- ✅ Creato GOVERNANCE.md (policy e ownership)
+- ✅ Indice taggato per ruolo (non tecnico / tecnico / storico)
+- ✅ Identificati documenti canonici per tema
+- ✅ Creata sezione Info (percorso non tecnico)
+- ✅ Documentazione legacy spostata in Archive
 
 ## 🔍 Navigazione Rapida
 

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -1,0 +1,50 @@
+---
+status: "[STORICO]"
+last-updated: 2026-06-14
+owner: Historian
+---
+
+# 📦 Archive — Documenti Storici
+
+Tutti i documenti in questa cartella sono **storici** e **non operativi**. Rappresentano:
+
+- Decisioni passate e loro analisi
+- Report di incidenti e problemi risolti
+- Configurazioni e design obsoleti
+- Feedback e feature proposte (archiviate)
+
+## Organizzazione
+
+```
+archive/
+  ├── analysis/           # Analisi decisionali passate (MAPCN, evaluations, etc.)
+  ├── incidents/          # Report di incidenti e problemi
+  ├── security/           # Configurazioni security legacy
+  ├── project/            # Feedback, bugs tracking, AI instructions
+  └── README.md           # Questo file
+```
+
+## Come leggere documenti qui
+
+1. **Verificare la data** — Capire il contesto storico
+2. **Controllare il contesto** — Quale problema risolvevano?
+3. **NON usare per operazioni** — Sono obsoleti
+4. **Usare per capire decisioni** — Utili per capire perché il codice è così
+
+## Criteri di archiviazione
+
+Un documento viene archiviato quando:
+- ✅ Non è più operativo (versione nuova esiste in docs/)
+- ✅ È un report storico (incidente, analisi passata)
+- ✅ È un feedback/proposta non implementata
+- ✅ È un design precedente rimpiazzato
+
+## Per chi cerca informazioni
+
+- **Sviluppatore nuovo**: Leggi i documenti **operativi** in [docs/](../README.md), non qui
+- **Storico del progetto**: Benvenuto! Questa è la fonte di verità per il contesto
+- **Decisore**: Leggi il [GOVERNANCE.md](../GOVERNANCE.md) per policy attuali
+
+---
+
+Ultima sincronizzazione: 14 giugno 2026

--- a/docs/info/START-HERE.md
+++ b/docs/info/START-HERE.md
@@ -1,0 +1,83 @@
+---
+status: "[OPERATIVO]"
+last-updated: 2026-06-14
+owner: UX Writer
+---
+
+# 🚀 Inizia da qui!
+
+Benvenuto ad **ATLITEG** — Atlante della lingua e dei testi della cultura gastronomica italiana.
+
+Questo è il percorso più veloce per comprendere il progetto **senza conoscenze tecniche**.
+
+---
+
+## ✨ Cosa è ATLITEG?
+
+ATLITEG è una **mappa interattiva che racconta la storia della lingua gastronomica italiana** dal Medioevo all'Unità d'Italia.
+
+### A cosa serve?
+
+- 🗺️ **Esplorare** dove e quando i termini gastronomici erano usati
+- 📚 **Scoprire** l'evoluzione storica dei nomi di cibi e pietanze
+- 🔍 **Ricercare** specifici lemmi e loro varianti regionali
+- 📊 **Analizzare** pattern geografici e storici
+
+### Chi lo usa?
+
+- Ricercatori di linguistica storica
+- Studenti di studi italiani
+- Appassionati di gastronomia e storia
+- Decisori e stakeholder istituzionali
+
+---
+
+## 🎯 Primo accesso: 3 step
+
+### 1️⃣ Accedi al sito
+Vai a: https://atlante.atliteg.org (oppure https://linguistica.dh.unica.it/atliteg)
+
+### 2️⃣ Guarda la mappa
+Vedrai una **mappa dell'Italia** con cerchi colorati (blu = pochi occorrenze, rosso = molte occorrenze).
+
+### 3️⃣ Cerca un termine
+Clicca sul campo di ricerca, digita un nome di cibo (es. "pane", "vino", "pasta") e esplora i risultati.
+
+---
+
+## 🎮 Funzionalità Principali (5 min overview)
+
+| Funzione | Come usarla | Risultato |
+|----------|------------|----------|
+| **Ricerca** | Scrivi una parola nella barra in alto | Vedi la distribuzione geografica |
+| **Mappa** | Clicca sui cerchi | Vedi i lemmi specifici in quella zona |
+| **Timeline** | Scorri in basso | Vedi come il termine è cambiato nel tempo |
+| **Filtri** | Seleziona categoria/periodo | Ristringe i risultati |
+| **Indice A-Z** | Clicca sulle lettere | Sfoglia lemmi alfabeticamente |
+
+---
+
+## 📖 Leggi di più
+
+Per una guida completa, vedi:
+- [Guida Utente Breve (10 min)](guida-utente-breve.md)
+- [FAQ — Domande frequenti](faq.md)
+
+Per aspetti tecnici, vedi [Indice Completo Documentazione](../README.md).
+
+---
+
+## 💡 Domanda frequente
+
+**D: È veramente gratuito e open?**  
+R: Sì! ATLITEG è un progetto di ricerca finanziato da PRIN 2017. Puoi usarlo, scaricare i dati, e contribuire.
+
+**D: Posso usare questi dati per i miei articoli/presentazioni?**  
+R: Sì, con attribuzione. Cita: "ATLITEG - Atlante della lingua e dei testi della cultura gastronomica italiana"
+
+**D: Come posso segnalare errori nei dati?**  
+R: Apri una issue su [GitHub Issues](https://github.com/Unica-dh/atliteg-map/issues)
+
+---
+
+**Pronti? Inizia a esplorare:** → [Mappa ATLITEG](https://atlante.atliteg.org)

--- a/docs/info/faq.md
+++ b/docs/info/faq.md
@@ -1,0 +1,161 @@
+---
+status: "[OPERATIVO]"
+last-updated: 2026-06-14
+owner: UX Writer
+---
+
+# ❓ FAQ — Domande Frequenti
+
+## Uso Generale
+
+**D: Cos'è ATLITEG?**  
+R: ATLITEG è una mappa interattiva che visualizza la storia della lingua gastronomica italiana dal Medioevo all'Unità (1861).
+
+**D: Come accedo?**  
+R: Vai a https://atlante.atliteg.org oppure https://linguistica.dh.unica.it/atliteg
+
+**D: Devo registrarmi?**  
+R: No, l'accesso è completamente gratuito e anonimo.
+
+**D: È disponibile su mobile?**  
+R: Sì, ma l'interfaccia è ottimizzata per desktop. Su mobile, la mappa è leggermente più piccola.
+
+---
+
+## Ricerca e Filtri
+
+**D: Come cerco un termine specifico?**  
+R: Usa la barra di ricerca in alto e digita la parola.
+
+**D: Posso cercare più termini contemporaneamente?**  
+R: Attualmente no, ma puoi cercare uno alla volta e navigare i risultati.
+
+**D: Cosa significano i colori sulla mappa?**  
+R: Blu = poche occorrenze, Arancione = moderate, Rosso = molte.
+
+**D: Come uso i filtri?**  
+R: Seleziona una **categoria** (tipo di alimento) e un **periodo storico**. La mappa si aggiorna automaticamente.
+
+**D: Posso resettare tutti i filtri?**  
+R: Sì, c'è un pulsante "Reset" nei controlli dei filtri.
+
+---
+
+## Dati e Fonti
+
+**D: Da dove vengono i dati?**  
+R: Dal **VoSLIG** (Vocabolario Storico della Lingua Italiana Gastronomica), progetto di ricerca finanziato da PRIN 2017.
+
+**D: Quanti lemmi sono disponibili?**  
+R: Attualmente circa 4,000+ lemmi e varianti regionali.
+
+**D: I dati sono completi?**  
+R: No, è un progetto in evoluzione. I dati rappresentano le fonti storiche disponibili e studiate.
+
+**D: Cosa sono le "attestazioni"?**  
+R: Il numero di volte che un termine appare nei testi storici studiati.
+
+**D: Posso scaricare i dati grezzi?**  
+R: Sì, i dati sono disponibili su [GitHub](https://github.com/Unica-dh/atliteg-map) (per utenti tecnici).
+
+---
+
+## Tecnologia e Performance
+
+**D: Qual è il browser consigliato?**  
+R: Chrome, Firefox, Safari, o Edge (versioni recenti). Su mobile, usa il browser del tuo dispositivo.
+
+**D: La mappa è lenta. Perché?**  
+R: Potrebbe essere dovuto a:
+- Connessione internet lenta
+- Troppi marker sulla mappa (prova a filtrare)
+- Browser datato (aggiorna alla versione recente)
+
+**D: Quanti marker può gestire la mappa?**  
+R: Fino a 10,000+ marker, con clustering automatico.
+
+---
+
+## Citazione e Uso Accademico
+
+**D: Posso usare ATLITEG per i miei articoli/presentazioni?**  
+R: Sì! Cita come segue:
+```
+ATLITEG - Atlante della lingua e dei testi della cultura gastronomica italiana.
+Università Roma Tre (Labgeo) e Università per Stranieri di Siena (PRIN 2017).
+https://atlante.atliteg.org
+```
+
+**D: Posso usare i screenshot?**  
+R: Sì, con attribuzione come sopra.
+
+**D: Posso contattare i ricercatori?**  
+R: Sì, apri una [issue su GitHub](https://github.com/Unica-dh/atliteg-map/issues) oppure visita il sito del progetto.
+
+---
+
+## Problemi Tecnici
+
+**D: La mappa non carica affatto.**  
+R: Prova:
+1. Ricarica la pagina (F5)
+2. Cancella la cache (Ctrl+Shift+Delete)
+3. Usa un browser diverso
+4. Controlla la tua connessione internet
+
+**D: Un filtro non funziona.**  
+R: Prova a:
+1. Resettare tutti i filtri
+2. Ricarica la pagina
+3. Segnala il bug su [GitHub Issues](https://github.com/Unica-dh/atliteg-map/issues)
+
+**D: La ricerca mostra "No results" anche per termini comuni.**  
+R: Potrebbe essere dovuto a:
+- Errori di ortografia (i termini sono storici, possono differire dall'italiano moderno)
+- Filtri troppo restrittivi
+- Prova a resettare e ricercare senza filtri
+
+**D: I numeri della dashboard non corrispondono ai marker sulla mappa.**  
+R: I numeri si aggiornano quando applichi filtri. Resetta i filtri per vedere i totali globali.
+
+---
+
+## Miglioramenti e Feedback
+
+**D: Come segnalo un bug?**  
+R: Apri una [issue su GitHub](https://github.com/Unica-dh/atliteg-map/issues/new/choose) con una descrizione chiara.
+
+**D: Posso suggerire una nuova funzionalità?**  
+R: Sì! Apri una [GitHub Discussion](https://github.com/Unica-dh/atliteg-map/discussions) o una issue con il tag `enhancement`.
+
+**D: Posso contribuire al progetto?**  
+R: Sì! Vedi [Linee guida per contribuire](../project/CONTRIBUTING.md).
+
+---
+
+## Partner e Collaborazioni
+
+**D: Chi c'è dietro ATLITEG?**  
+R: 
+- **Università Roma Tre** — Labgeo "Giuseppe Caraci"
+- **Università per Stranieri di Siena** — Responsabile scientifica (prof.ssa Giovanna Frosini)
+- **DH Unica** — Centro Digital Humanities (Università di Cagliari)
+- **Finanziamento**: PRIN 2017
+
+**D: È un progetto accademico?**  
+R: Sì, è un progetto di ricerca universitaria peer-reviewed.
+
+---
+
+## Non trovi la risposta?
+
+Contatta i ricercatori:
+- 📧 Email: [info disponibile su GitHub](https://github.com/Unica-dh/atliteg-map)
+- 🐙 GitHub: [Apri una issue](https://github.com/Unica-dh/atliteg-map/issues)
+- 🌐 Sito del progetto: [atliteg.org](https://atliteg.org)
+
+---
+
+Leggi anche:
+- [START-HERE](START-HERE.md) — Guida veloce (3 min)
+- [Guida Utente Breve](guida-utente-breve.md) — Tutorial completo (10 min)

--- a/docs/info/guida-utente-breve.md
+++ b/docs/info/guida-utente-breve.md
@@ -1,0 +1,126 @@
+---
+status: "[OPERATIVO]"
+last-updated: 2026-06-14
+owner: UX Writer
+---
+
+# 📖 Guida Utente Breve (10 min)
+
+Guida completa per utenti non tecnici su come usare ATLITEG.
+
+## Come accedere
+
+1. Vai a **https://atlante.atliteg.org**
+2. Aspetta il caricamento della mappa
+
+## La mappa
+
+**Cosa vedi:**
+- Mappa dell'Italia con **cerchi colorati**
+- **Blu**: poche occorrenze di un termine
+- **Arancione**: occorrenze moderate
+- **Rosso**: molte occorrenze
+
+**Come navigare:**
+- Usa lo **scroll del mouse** per zoom in/out
+- **Clicca e trascina** per muoverti
+- **Doppio click** per zoom automatico
+
+## Ricerca
+
+**Barra di ricerca** (in alto):
+1. Clicca sul campo di ricerca
+2. Digita una parola (es. "pane")
+3. Premi **Invio** o aspetta l'autocompletamento
+
+**Risultati:**
+- La mappa si aggiorna automaticamente
+- I cerchi mostrano la distribuzione geografica
+- Clicca su un cerchio per dettagli specifici
+
+## Timeline (evoluzione storica)
+
+Scorri verso il **basso a destra** per vedere:
+- **Istogramma** dei termini nel tempo
+- **Periodi storici**: divisi in quarti di secolo
+- Vedrai come la frequenza cambia nel Medioevo → Rinascimento → Unità
+
+## Filtri
+
+### Categoria
+Seleziona il tipo di alimento:
+- Piatti principali
+- Ingredienti
+- Bevande
+- Spezie
+- etc.
+
+### Periodo
+Seleziona l'epoca storica:
+- Medioevo
+- Rinascimento
+- Età moderna
+- etc.
+
+**Tip**: Usa più filtri insieme per analisi specifiche.
+
+## Indice Alfabetico
+
+Sulla **sinistra** vedi le lettere A-Z. Clicca per:
+- Sfogliare alfabeticamente
+- Jumpare a una lettera specifica
+- Vedisottosotto il numero di lemmi per lettera
+
+## Pannello Dettagli
+
+Clicca su un **cerchio sulla mappa** per aprire il pannello con:
+- **Nome del lemma** (forma principale)
+- **Forme varianti** (altre scritture)
+- **Distribuzione geografica** (regioni)
+- **Timeline** (quando era usato)
+- **Attestazioni** (quante volte registrato)
+
+## Metriche Dashboard
+
+In **alto a destra** vedi:
+- Numero totale di **lemmi** trovati
+- Numero di **località**
+- **Anno** inizio/fine
+- Numero di **attestazioni** totali
+
+Questi numeri si aggiornano filtri.
+
+## Export e Condivisione
+
+Attualmente ATLITEG non supporta export diretto, ma puoi:
+- 📸 Scattare screenshot della mappa
+- 🔗 Copiare l'URL della pagina (i filtri rimangono nell'URL)
+- 📄 Scaricare i dati grezzi da GitHub (per tecnici)
+
+## Troubleshooting
+
+### "La mappa non carica"
+- Ricarica la pagina
+- Verifica la connessione internet
+- Prova un browser diverso
+
+### "La ricerca è lenta"
+- Aspetta qualche secondo
+- Digita parole più specifiche
+- Deseleziona alcuni filtri
+
+### "I numeri non corrispondono"
+- I filtri attivi cambiano i conteggi
+- Resetta tutti i filtri se vuoi i totali
+
+---
+
+## Leggi di più
+
+- [START-HERE](START-HERE.md) — Introduzione veloce (3 min)
+- [FAQ](faq.md) — Domande frequenti
+- [Indice Completo](../README.md) — Documentazione tecnica
+
+---
+
+**Pronti? Inizia a esplorare:** → [Mappa ATLITEG](https://atlante.atliteg.org)


### PR DESCRIPTION
- Add GOVERNANCE.md with policy for document status, ownership, naming
- Restructure docs/README.md as canonical index with role-based tagging
- Add [Non tecnico], [Tecnico], [STORICO] tags to all doc links
- Identify single source of truth for each theme
- Snellify root README.md to landing page + link to docs/
- Create docs/info/ section (non-technical path):
  * START-HERE.md — 3 min quickstart
  * guida-utente-breve.md — 10 min full guide
  * faq.md — user-friendly Q&A
- Create docs/archive/ for historical documents
- Ready for phases 2-5 (fix critical + accorpamenti)
